### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,5 @@ cd / && pipenv run /gh2jira sync \
                             --direction "$INPUT_SYNC_DIRECTION" \
                             --issue-end-state "$INPUT_ISSUE_END_STATE" \
                             --issue-reopen-state "$INPUT_ISSUE_REOPEN_STATE" \
+                            --issue-type "$INPUT_ISSUE_TYPE" \
                             --state-issue -


### PR DESCRIPTION
While running the codeQL workflow I am getting an below error 

jira.exceptions.JIRAError: JiraError HTTP 400 url: https://appdirect.jira.com/rest/api/2/issue
	text: The issue type selected is invalid.
	
	response headers = {'Date': 'Thu, 16 Mar 2023 10:26:42 GMT', 'Content-Type': 'application/json;charset=UTF-8', 'Server': 'AtlassianEdge', 'Timing-Allow-Origin': '*', 'X-Arequestid': '1c60e4a0323c02f1aa5a019a4e4a390e', 'X-Aaccountid': '628dac6ff2261e00682a1d81', 'Cache-Control': 'no-cache, no-store, no-transform', 'Expect-Ct': 'report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/atlassian-proxy", max-age=86400', 'X-Content-Type-Options': 'nosniff', 'X-Xss-Protection': '1; mode=block', 'Atl-Traceid': 'bbef14085d9225f9', 'Report-To': '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group": "endpoint-1", "include_subdomains": true, "max_age": 600}', 'Nel': '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to": "endpoint-1"}', 'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload', 'Transfer-Encoding': 'chunked'}
	response text = {"errorMessages":[],"errors":{"issuetype":"The issue type selected is invalid."}}

as I can see the issue type hasn't been added to workflow . Can you help me out to resolve the above error.

Thanks!!